### PR TITLE
Update Libreoffice and R, allow configuration of subnet, update readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt
+          packer plugins install github.com/hashicorp/amazon
 
       - name: Run checks
         run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Packer templates for building TRE AMIs
 HIC build AMIs (Amazon Machine Images) for use in the HIC TRE using [Packer](https://www.packer.io/).
 These AMIs are all very similar so we've written some tools to make it easier to template them.
 
+## Prerequisites
+
+You must install Packer and Python 3.
+You will also need access to an AWS account.
+
+If you are using a recent version of Packer you may also need to install the Amazon plugin:
+```
+packer plugins install github.com/hashicorp/amazon
+```
+
 ## Usage
 
 Two example configurations are provided in the `configs` directory, one for Windows 2019 and one for Ubuntu 22.04 desktop.

--- a/modules/libreoffice.ps1
+++ b/modules/libreoffice.ps1
@@ -3,8 +3,8 @@ $ProgressPreference = 'SilentlyContinue' # Disable (slow) progress bar
 
 Set-Location C:\Tools
 
-$LIBRE_VERSION = "7.6.3"
-$LIBRE_HASH    = "65a1330abaddf31e4dd8cb9c1110f422a3edc828b8d5680bcd3ea8efa508ef3c"
+$LIBRE_VERSION = "24.2.0"
+$LIBRE_HASH    = "58dcf13d87ef1279f7229b69949b836b73ce5f039ddb54cdf091f8fea28cc9f2"
 
 $LIBRE_URL = "https://mirrors.ukfast.co.uk/sites/documentfoundation.org/tdf/libreoffice/stable/${LIBRE_VERSION}/win/x86_64/LibreOffice_${LIBRE_VERSION}_Win_x86-64.msi"
 

--- a/modules/rstudio.ps1
+++ b/modules/rstudio.ps1
@@ -1,15 +1,16 @@
 Set-Location C:\Tools
 
 $ProgressPreference = "SilentlyContinue" # PS progress bar is slow
+$ErrorActionPreference = "Stop"
 
 # R environment
 Invoke-WebRequest -Uri "https://cloud.r-project.org/bin/windows/base/R-4.3.2-win.exe" -OutFile C:\Tools\R-installer.exe
 Start-Process C:\Tools\R-installer.exe -ArgumentList "/VERYSILENT","/NORESTART" -NoNewWindow -Wait -PassThru
 
-Invoke-WebRequest -Uri "https://s3.amazonaws.com/rstudio-ide-build/electron/windows/RStudio-2023.09.1-494.exe" -OutFile C:\Tools\RStudio-installer.exe
+Invoke-WebRequest -Uri "https://download1.rstudio.org/electron/windows/RStudio-2023.12.1-402.exe" -OutFile C:\Tools\RStudio-installer.exe
 Start-Process C:\Tools\RStudio-installer.exe -ArgumentList "/S" -NoNewWindow -Wait -PassThru
 
-Invoke-WebRequest -Uri "https://cran.r-project.org/bin/windows/Rtools/rtools43/files/rtools43-5863-5818.exe" -OutFile C:\Tools\RTools.exe
+Invoke-WebRequest -Uri "https://cloud.r-project.org/bin/windows/Rtools/rtools43/files/rtools43-5958-5975.exe" -OutFile C:\Tools\RTools.exe
 Start-Process C:\Tools\RTools.exe -ArgumentList "/VERYSILENT" -NoNewWindow -Wait -PassThru
 
 $RConfig = @"

--- a/templates/ubuntu.pkr.hcl
+++ b/templates/ubuntu.pkr.hcl
@@ -45,6 +45,10 @@ source "amazon-ebs" "ubuntu2004" {
     delete_on_termination = true
   }
 
+{% if subnet_id %}
+  subnet_id = "{{ subnet_id }}"
+{% endif %}
+
 {% if s3_resources %}
   temporary_iam_instance_profile_policy_document {
     Statement {

--- a/templates/windows.pkr.hcl
+++ b/templates/windows.pkr.hcl
@@ -45,6 +45,10 @@ source "amazon-ebs" "windows" {
     volume_size = {{ instance.volume_size }}
   }
 
+{% if subnet_id %}
+  subnet_id = "{{ subnet_id }}"
+{% endif %}
+
 {% if s3_resources %}
   temporary_iam_instance_profile_policy_document {
     Statement {


### PR DESCRIPTION
The LibreOffice and RTools downloads links have broken (again).

Also adds support for configuring the `subnet_id` in case a default VPC doesn't exist.