### PR TITLE
Add aws_ec2launch.ps1 module

### DIFF
--- a/modules/aws_ec2launch.ps1
+++ b/modules/aws_ec2launch.ps1
@@ -1,0 +1,8 @@
+# https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch-v2-install.html
+Set-Location C:\Tools
+
+$ProgressPreference = "SilentlyContinue" # PS progress bar is slow
+$ErrorActionPreference = "Stop"
+
+Invoke-WebRequest -Uri "https://s3.amazonaws.com/amazon-ec2launch-v2/windows/amd64/latest/AmazonEC2Launch.msi" -OutFile C:\Tools\AmazonEC2Launch.msi
+msiexec /i AmazonEC2Launch.msi /quiet


### PR DESCRIPTION
This is needed for base AMIs that do not include EC2Launch, such as the Windows NiceDCV AMIs